### PR TITLE
Add server name tooltip with full name

### DIFF
--- a/OnlinePlayersWindow/OnlineNexusPlayersWindow.cs
+++ b/OnlinePlayersWindow/OnlineNexusPlayersWindow.cs
@@ -623,7 +623,7 @@ namespace SeamlessClient.OnlinePlayersWindow
             }
 
 
-            row.AddCell(new MyGuiControlTable.Cell(ServerName));
+            row.AddCell(new MyGuiControlTable.Cell(ServerName, toolTip: ServerName));
 
 
             m_playersTable.Add(row);
@@ -709,7 +709,7 @@ namespace SeamlessClient.OnlinePlayersWindow
             }
 
 
-            row.AddCell(new MyGuiControlTable.Cell(ServerName));
+            row.AddCell(new MyGuiControlTable.Cell(ServerName, toolTip: ServerName));
 
 
             m_playersTable.Add(row);


### PR DESCRIPTION
Fixes an issue where the server name in the F3 menu is cut off if too long without a way to see the full name.